### PR TITLE
ci: set up soldeer autopublish for rain-pyth

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -1,0 +1,11 @@
+name: Package Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
+    with:
+      soldeer-package: rain-pyth
+    secrets: inherit

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,7 @@
+[package]
+name = "rain-pyth"
+version = "0.1.0"
+
 [profile.default]
 libs = ["dependencies"]
 


### PR DESCRIPTION
Towards #22 — publish rain.pyth to the soldeer registry.

Now that rain.pyth is de-submoduled (#23 merged), it can be published. This wires it up:
- Add `[package]` (`name = "rain-pyth"`, `version = "0.1.0"` — first release; no prior tags/registry entry) to `foundry.toml`.
- Add `package-release.yaml` calling `rainix-autopublish` (`soldeer-package: rain-pyth`), which publishes `rain-pyth~<version>` on push to main when the foundry.toml version diverges from the registry.

⚠️ **First-publish gate:** the `rain-pyth` project must be **created on soldeer.xyz** before the first push succeeds — the registry rejects pushes to a nonexistent project, and the workflow does not create it. After this PR merges, the `package-release` job will attempt `rain-pyth~0.1.0` and fail until the project exists; once created, re-run (or next push) publishes and #22 can close.