### PR TITLE
soldeer: add .soldeerignore (unblock autopublish push)

### DIFF
--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: LicenseRef-DCL-1.0
+# SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+
 # Publish only the Solidity source (src/) to Soldeer. Without this, the push
 # zips the whole repo tree — including dotfiles soldeer flags as "sensitive" —
 # which hangs the non-interactive CI publish on a confirmation prompt

--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,0 +1,31 @@
+# Publish only the Solidity source (src/) to Soldeer. Without this, the push
+# zips the whole repo tree — including dotfiles soldeer flags as "sensitive" —
+# which hangs the non-interactive CI publish on a confirmation prompt
+# ("error during IO operation: not connected"). Same syntax as .gitignore.
+
+# Tooling / repo dotfiles
+.DS_Store
+.envrc
+.gas-snapshot
+.git
+.github
+.gitignore
+.pre-commit-config.yaml
+.soldeerignore
+slither.config.json
+
+# Non-source trees / build output (consumers import rain-pyth-x.y.z/src/ only)
+/cache
+/dependencies
+/flake.lock
+/flake.nix
+/foundry.lock
+/foundry.toml
+/meta
+/node_modules
+/out
+/remappings.txt
+/REUSE.toml
+/script
+/soldeer.lock
+/test


### PR DESCRIPTION
rain-pyth's first soldeer publish hangs because `forge soldeer push` flags repo dotfiles as sensitive and prompts for confirmation — CI has no stdin, so it errors `during IO operation: not connected`. Mirrors raindex's `.soldeerignore` (publish only `src/` + license/readme). Merging this re-triggers package-release, which should then publish `rain-pyth~0.1.0`. Towards #22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Soldeer publishing settings to exclude non-source files and directories from distribution, ensuring cleaner and more efficient package releases while preventing unnecessary files from being included in published packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->