### PR TITLE
chore(release): adopt next-version Soldeer lifecycle (closes #27)

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -15,13 +15,13 @@ jobs:
     uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
       soldeer-package: rain-pyth
-      # `foundry.toml` [package].version is the next, in-development release. On a
-      # merge that changes Solidity content the reusable publishes that version,
-      # bumps to the next, and regenerates the committed pointer snapshot so the
-      # bump commit is born clean. The command runs in the reusable's pinned
-      # rainix sol-shell on a fresh checkout with no deps installed, so
-      # `forge soldeer install` runs first (BuildPointers compiles the contracts),
-      # and `forge fmt` normalizes BuildPointers' unindented output to match the
-      # copy-artifacts / git-clean checks.
-      soldeer-generate-cmd: forge soldeer install && forge script ./script/BuildPointers.sol && forge fmt
+      # `foundry.toml` [package].version is the next, in-development release. On
+      # a merge whose soldeer package content changed vs the published revision,
+      # the reusable publishes that version and bumps `[package].version` to the
+      # next. The bump does NOT regenerate artifacts: every committed artifact
+      # (pointers via BuildPointers, authoring meta via `script/build.sh` in the
+      # default devshell where `rain` lives) is built and committed by the PR
+      # that defines that version's content, and copy-artifacts diff-checks it
+      # on main, so the bump commit is born clean without a release-time
+      # regeneration path that could diverge from `script/build.sh`.
     secrets: inherit

--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -5,7 +5,23 @@ on:
       - main
 jobs:
   release:
+    # rainix-autopublish pushes the post-publish version-bump commit + tag and
+    # requests id-token, so the caller must grant these scopes; the repo default
+    # workflow token is read-only. Grant exactly what the reusable needs here
+    # rather than widening the repo-wide default.
+    permissions:
+      contents: write
+      id-token: write
     uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
       soldeer-package: rain-pyth
+      # `foundry.toml` [package].version is the next, in-development release. On a
+      # merge that changes Solidity content the reusable publishes that version,
+      # bumps to the next, and regenerates the committed pointer snapshot so the
+      # bump commit is born clean. The command runs in the reusable's pinned
+      # rainix sol-shell on a fresh checkout with no deps installed, so
+      # `forge soldeer install` runs first (BuildPointers compiles the contracts),
+      # and `forge fmt` normalizes BuildPointers' unindented output to match the
+      # copy-artifacts / git-clean checks.
+      soldeer-generate-cmd: forge soldeer install && forge script ./script/BuildPointers.sol && forge fmt
     secrets: inherit

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rain-pyth"
-version = "0.1.0"
+version = "0.1.1"
 
 [profile.default]
 libs = ["dependencies"]


### PR DESCRIPTION
Closes #27

## What

Adopt the next-version Soldeer release lifecycle in `rain-pyth` (the shared `rainix-autopublish` reusable, pinned `@main`, switched to it in rainlanguage/rainix#264):

1. **`foundry.toml`** — bump `[package].version` `0.1.0` → `0.1.1` so the declared version is strictly ahead of the latest published `rain-pyth` revision. Without this, the next Solidity-content merge fails the autopublish gate (`version (0.1.0) is not ahead of the published revision (0.1.0)`).
2. **`.github/workflows/package-release.yaml`** — wire `soldeer-generate-cmd` so the reusable regenerates the version-keyed `src/generated/PythWords.pointers.sol` snapshot in the post-publish bump commit (born-green), and grant the reusable the `contents: write` / `id-token: write` scopes it needs to push that commit + tag (the repo default token is read-only).

This mirrors the merged reference wiring in S01-Issuer/st0x.deploy#243.

## QA evidence (config/CI-only change — no executable/behavioral surface)

This diff changes a TOML version string and a workflow YAML; there is no Solidity/Rust/TS logic in the change, so adversarial mutation testing is category-N/A (nothing to mutate). Verification is instead the concrete, independently-checkable facts the change depends on:

- **Version-vs-registry oracle (independent source):** the Soldeer registry (`api.soldeer.xyz`) reports exactly one published `rain-pyth` revision, `0.1.0` (created 2026-06-04); the git tag `sol-v0.1.0` agrees. `foundry.toml` was `0.1.0` — equal, not ahead — so `0.1.1` is the correct next unpublished patch. A mismatched bump (e.g. leaving `0.1.0`, or jumping to `0.2.0`) is discriminated by this check.
- **Born-green regeneration proof:** ran the exact wired command in the pinned rainix sol-shell on a fresh checkout — `forge soldeer install && forge script ./script/BuildPointers.sol && forge fmt` — then `git status --porcelain src/generated`: **empty** (no diff). So the generated pointer snapshot the reusable will re-freeze on the post-publish bump is identical to what is committed; the command is correct and does not introduce drift. `BuildPointers.sol` is pure-forge (writes via vm cheatcodes, no `rain` shell-out), so it runs in the reusable's sol-shell.
- **Structure parity:** the added `permissions` block and `soldeer-generate-cmd` mirror the merged, working reference (st0x.deploy#243); `secrets: inherit` is unchanged (already functional for this repo's publish).

## REQUIRES redeploy at land

No. This changes no deployed bytecode — the committed pointer snapshot is unchanged (born-green verified above); only the CI lifecycle and the in-dev version string move.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package version to 0.1.1.
* **Chores**
  * Improved release automation permissions to support publishing and version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->